### PR TITLE
bionic: use jemalloc by default and allow opt-in to scudo (3/3)

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -128,7 +128,7 @@ cc_defaults {
                 malloc_pattern_fill_contents: {
                     cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
                 },
-                malloc_not_svelte: {
+                malloc_use_scudo: {
                     cflags: ["-DUSE_SCUDO"],
                 },
             },
@@ -154,7 +154,7 @@ cc_defaults {
 }
 
 libc_scudo_product_variables = {
-    malloc_not_svelte: {
+    malloc_use_scudo: {
         cflags: ["-DUSE_SCUDO"],
         whole_static_libs: ["libscudo"],
         exclude_static_libs: [
@@ -178,9 +178,6 @@ libc32_scudo_product_variables = {
 
 // Defaults for native allocator libs/includes to make it
 // easier to change.
-// To disable scudo for the non-svelte config remove the line:
-//     product_variables: libc_scudo_product_variables,
-// in the cc_defaults below.
 // ========================================================
 cc_defaults {
     name: "libc_native_allocator_defaults",


### PR DESCRIPTION
Overall, jemalloc performs 10-20% better than Scudo while consuming equivalent amount of memory in system/extra's real-world memory_replay traces:

https://docs.google.com/spreadsheets/d/1E5d_YcU04i8zA-V0vcJgilONGICvR6ynfYGMAvSnMvg/edit?usp=sharing

Scudo performs fairly well for a hardened memory allocator, but we're optimizing for performance.

Tests were performed by statically linking memory_replay under PA Sapphire branch. Android userspace has been stopped before performing all benchmarks, and each test was executed 10 times with an idle detector in between to reduce noise and errors.

The entire test took about 18 hours:
https://github.com/arter97/android_memory_replay_helper

Few notes:

 - jemalloc shipped with android-12.1.0_r5, v5.1.0, performs consistently better than v5.2.1, especially with the camera trace, but generally consumes more memory.

 - jemalloc v5.3.0 is not benchmarked yet due to on going Android compatibility issues: https://github.com/jemalloc/jemalloc/issues/2279

 - Scudo from android-12.1.0_r8 consumes 5.5% less memory compared to Qualcomm's Scudo, and the performance is equivalent (0.2% better).

This commit has been inspired from https://github.com/ProtonAOSP/android_bionic/commit/b2204890eac02f54738a8d9e17c93643ff0aff60

Change-Id: I84264c07b1bc8c9dc69fd1dde48a2c7c9609d82d